### PR TITLE
Added missing glib includes directory

### DIFF
--- a/trustlet/net_flow/setup.py
+++ b/trustlet/net_flow/setup.py
@@ -4,7 +4,9 @@ extension_mod = Extension("_net_flowmodule",
                           ["lib/_net_flowmodule.cc", "lib/net_flow.cc"],
                           libraries=['glib-2.0', 'stdc++'],
                           include_dirs=['/usr/include/glib-2.0',
-                                        '/usr/lib/glib-2.0/include'])
+                                        '/usr/lib/glib-2.0/include',
+                                        '/usr/lib64/glib-2.0/include',
+                                        '/usr/lib/x86_64-linux-gnu/glib-2.0/include'])
 
 setup(name="net_flow",
       package_dir = {'': 'lib'},


### PR DESCRIPTION
This would prevent a compilation error for `net_flow` module on some 64bits distributions.

![screenshot_2018-06-12_16-12-42](https://user-images.githubusercontent.com/6185849/41299523-857f4584-6e5b-11e8-9036-004c5b074952.png)
